### PR TITLE
set the trap in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy
 scipy
 matplotlib
-pandas
+jupyter
+sphinx
+flake8


### PR DESCRIPTION
cc @bmcfee, this removes numpy from our requirements so we can add it back.